### PR TITLE
Added the ignore table option to ignore history

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## OVERVIEW
 
-This is a script that creates a full backup of the Zabbix database. It is useful to automate Zabbix DB backups with a _crontab_ or some other tool like Zabbix itself, and keep the backups consistent. Along with it, a useful template that pulls the script log data into Zabbix.
+This is a script that creates a backup of the Zabbix database. It is useful to automate Zabbix DB backups with a _crontab_ or some other tool like Zabbix itself, and keep the backups consistent. Along with it, a useful template that pulls the script log data into Zabbix.
 
 The script uses `mysqldump` to produce a set of SQL statements from the Zabbix MySQL database for backup purposes. It also reduces the size of the database dump by compressing it with `gzip`. During this process, the script records the execution to a log file and writes some statistics.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ The template is ready to read the script log statistics with a Zabbix Agent in a
 **1.** Add execute permission to the script file after downloading it to the Zabbix server.
 
 ```
-chmod +x zabbix_db_bkp_full.sh
+chmod ug+x zabbix_db_bkp_full.sh
+# OR
+chmod ug+x zabbix_db_bkp_no_hist.sh
 ```
 
 **2.1** **[`OPTION 1`]** To use a pre-set Zabbix DB authentication, set the authentication values inside the script at step `#002.001` and pass the `-d` argument when executing it.
@@ -71,8 +73,11 @@ chmod +x zabbix_db_bkp_full.sh
     dbuser="zabbix"            # SET HERE YOUR PRE-SET DB USERNAME
     dbpass="zabbix"            # SET HERE YOUR PRE-SET DB USERNAME'S PASSWORD
 ```
+
 ```
 ./zabbix_db_bkp_full.sh -d
+# OR
+./zabbix_db_bkp_no_hist.sh -d
 ```
 
 ---
@@ -83,6 +88,8 @@ chmod +x zabbix_db_bkp_full.sh
 
 ```
 ./zabbix_db_bkp_full.sh "[dbhost]" "[dbname]" "[dbuser]" "[dbpass]"
+# OR
+./zabbix_db_bkp_no_hist.sh "[dbhost]" "[dbname]" "[dbuser]" "[dbpass]"
 ```
 
 <BR>
@@ -91,7 +98,7 @@ chmod +x zabbix_db_bkp_full.sh
 
 - The default backup directory is set to the user's home directory (`$HOME`) and is named `zabbix_db_bkp`. This can be changed in step `#002` by changing the `bkpdir` variable.
 - The log file resides in the backup file directory within the `log` subdirectory.
-- The default backup filename is set to `zabbix_db_bkp_full`. A timestamp prefix is appended to the file in the `yyyyMMddhhmmss` format followed by the `.sql.gz` file extension. For example `20250109040001_zabbix_db_bkp_full.sql.gz`.
+- The default backup filename is set to `zabbix_db_bkp_full` or `zabbix_db_bkp_no_hist`. A timestamp prefix is appended to the file in the `yyyyMMddhhmmss` format followed by the `.sql.gz` file extension. For example `20250109040001_zabbix_db_bkp_full.sql.gz`.
 - By default, the script only keeps **`30`** days of backup files and deletes any backups older than that. This can be changed in step `#002` by modifying the `bkpdays` variable.
 - The script output is written both to the console and to the log file.
 
@@ -113,7 +120,8 @@ chmod +x zabbix_db_bkp_full.sh
 <BR>
 
 ---
-### ➡️ [Download Script](./zabbix_db_bkp_full.sh)
+### ➡️ [Download Full Backup Script](./zabbix_db_bkp_full.sh)
+### ➡️ [Download No History Backup Script](./zabbix_db_bkp_no_hist.sh)
 ---
 ### ➡️ [Download Template](./zabbix_db_backup_stats_template_v722.yaml)
 ---
@@ -121,6 +129,8 @@ chmod +x zabbix_db_bkp_full.sh
 ---
 
 <BR>
+
+## Template `Zabbix DB Backup Stats by Zabbix Agent Active`
 
 ## MACROS
 

--- a/zabbix_db_bkp_no_hist.sh
+++ b/zabbix_db_bkp_no_hist.sh
@@ -2,8 +2,9 @@
 
 # ZABBIX DATABASE FULL BACKUP
 # Author: diasdm
-# This script creates a full backup of the Zabbix database using mysqldump,
-# compresses it with gzip, and logs the process.
+# This script creates a backup of the Zabbix database using mysqldump,
+# while ignoring history, trend and audit tables, compresses it with gzip,
+# and logs the process.
 
 # REQUIREMENTS:
 #     - mysqldump
@@ -12,11 +13,11 @@
 # USAGE:
 #     To use a pre-set Zabbix DB authentication,
 #     set values below (#002.001) and pass the "-d" argument.
-#         ./zabbix_db_bkp_full.sh -d
+#         ./zabbix_db_bkp_no_hist.sh -d
 
 #     To use your Zabbix DB authentication as arguments,
 #     pass all arguments in the order below.
-#         ./zabbix_db_bkp_full.sh "[dbhost]" "[dbname]" "[dbuser]" "[dbpass]"
+#         ./zabbix_db_bkp_no_hist.sh "[dbhost]" "[dbname]" "[dbuser]" "[dbpass]"
 #     PS: THE DUMP MAY FAIL IF ANY ARGUMENT IS OUT OF ORDER
 
 
@@ -33,7 +34,7 @@ fi
 #002 VAR
 bkpdir=${HOME}/zabbix_db_bkp   # BACKUP LOCAL DIR
 bkplogdir=${bkpdir}/log        # BACKUP LOG DIR
-bkpname=zabbix_db_bkp_full     # BACKUP FILE NAME
+bkpname=zabbix_db_bkp_no_hist  # BACKUP FILE NAME
 bkpdays=30                     # NUMBER OF DAYS TO KEEP OLD BACKUP
 
 TIME=$(date +%Y%m%d%H%M%S)     # BACKUP FILE TIMESTAMP

--- a/zabbix_db_bkp_no_hist.sh
+++ b/zabbix_db_bkp_no_hist.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# ZABBIX DATABASE FULL BACKUP
+# Author: diasdm
+# This script creates a full backup of the Zabbix database using mysqldump,
+# compresses it with gzip, and logs the process.
+
+# REQUIREMENTS:
+#     - mysqldump
+#     - gzip
+
+# USAGE:
+#     To use a pre-set Zabbix DB authentication,
+#     set values below (#002.001) and pass the "-d" argument.
+#         ./zabbix_db_bkp_full.sh -d
+
+#     To use your Zabbix DB authentication as arguments,
+#     pass all arguments in the order below.
+#         ./zabbix_db_bkp_full.sh "[dbhost]" "[dbname]" "[dbuser]" "[dbpass]"
+#     PS: THE DUMP MAY FAIL IF ANY ARGUMENT IS OUT OF ORDER
+
+
+#001 REQUIREMENTS CHECK
+if ! which mysqldump > /dev/null; then
+    echo "Error: mysqldump binary was not found."
+    exit 1
+elif ! which gzip > /dev/null; then
+    echo "Error: gzip binary was not found."
+    exit 1
+fi
+
+
+#002 VAR
+bkpdir=${HOME}/zabbix_db_bkp   # BACKUP LOCAL DIR
+bkplogdir=${bkpdir}/log        # BACKUP LOG DIR
+bkpname=zabbix_db_bkp_full     # BACKUP FILE NAME
+bkpdays=30                     # NUMBER OF DAYS TO KEEP OLD BACKUP
+
+TIME=$(date +%Y%m%d%H%M%S)     # BACKUP FILE TIMESTAMP
+
+#002.001 VAR TEST
+if [[ "$*" = "-d" ]]; then
+    dbhost="localhost"         # SET HERE YOUR DEFAULT DB HOSTNAME
+    dbname="zabbix"            # SET HERE YOUR DEFAULT DB NAME
+    dbuser="zabbix"            # SET HERE YOUR DEFAULT DB USERNAME
+    dbpass="zabbix"            # SET HERE YOUR DEFAULT DB USERNAME'S PASSWORD
+else
+    if [[ -z "$1" ]]; then echo -e "\nDB HOST MISSING - ARG 1\n"; exit 2; fi
+    dbhost="$1"
+    if [[ -z "$2" ]]; then echo -e "\nDB NAME MISSING - ARG 2\n"; exit 2; fi
+    dbname="$2"
+    if [[ -z "$3" ]]; then echo -e "\nDB USER MISSING - ARG 3\n"; exit 2; fi
+    dbuser="$3"
+    if [[ -z "$4" ]]; then echo -e "\nDB PASSWORD MISSING - ARG 4\n"; exit 2; fi
+    dbpass="$4"
+fi
+
+
+#003 LOG WRITE
+# Logs messages to both console and log file.
+function log_write {
+    local logtime
+    logtime=$(date +%Y%m%d%H%M%S)
+    echo "${logtime} >> $1"
+    echo "${logtime} >> $1" >> "${bkplogdir}/${bkpname}.log"
+}
+
+
+#004 BACKUP DIR CREATION
+[[ ! -d "${bkpdir}" ]] && mkdir -v "${bkpdir}"
+[[ ! -d "${bkplogdir}" ]] && mkdir -v "${bkplogdir}"
+
+
+#005 LOG START MESSAGE
+clear
+echo ""
+
+STARTTIME=$(date +%s)
+
+log_write "------------------------------------------------"
+log_write "START"
+
+
+#006 MYSQL FULL DUMP
+log_write "Dumping \"${dbname}\" database"
+
+mysqldump -h"${dbhost}" -u"${dbuser}" -p"${dbpass}" \
+    --flush-logs \
+    --single-transaction \
+    --create-options \
+    --ignore-table="${dbname}".auditlog \
+    --ignore-table="${dbname}".history \
+    --ignore-table="${dbname}".history_bin \
+    --ignore-table="${dbname}".history_log \
+    --ignore-table="${dbname}".history_str \
+    --ignore-table="${dbname}".history_text \
+    --ignore-table="${dbname}".history_uint \
+    --ignore-table="${dbname}".trends \
+    --ignore-table="${dbname}".trends_uint \
+    "${dbname}" | gzip > "${bkpdir}/${TIME}_${bkpname}.sql.gz"
+
+if [[ "${PIPESTATUS[0]}" -eq 0 ]]; then
+    DUMPSTATE=0
+    log_write "DB dump complete"
+    log_write "Backup file: \"${bkpdir}/${TIME}_${bkpname}.sql.gz\""
+else
+    DUMPSTATE=1
+    log_write '## DB dump failed ##'
+fi
+
+
+#007 CLEAN UP OLD BACKUP
+# Stats may be pulled from Zabbix
+log_write "Excluding old backup with more than ${bkpdays} days"
+
+find "${bkpdir}"/* -mtime +${bkpdays} -exec rm -f {} +
+
+
+#008 LOG BACKUP TIME TAKEN AND FILE SIZE
+BKPBYTES=$(stat --printf="%s" "${bkpdir}/${TIME}_${bkpname}.sql.gz")
+BKPMEGAS=$(( BKPBYTES / 1024 ** 2 ))
+
+ENDTIME=$(date +%s)
+TOTALSEC=$(( ENDTIME - STARTTIME ))
+TOTALTIME=$(date -d@"$TOTALSEC" -u +%Hh%Mm%Ss)
+
+log_write "Backup file size: ${BKPBYTES}B - ${BKPMEGAS}MB"
+log_write "Backup total time: ${TOTALSEC}s - $TOTALTIME"
+log_write "Backup stats: {\"dump_state\":${DUMPSTATE},\"size\":${BKPBYTES},\"time\":${TOTALSEC}}"
+
+log_write "FINISH"
+
+exit 0


### PR DESCRIPTION
The `--ignore-table` option was added to ignore the _history*_, _trend_, and _auditlog_ tables.

> After the `--create-options` on line `90`, and before the `"${dbname}" | gzip...` argument.

```bash
    --ignore-table="${dbname}".auditlog \
    --ignore-table="${dbname}".history \
    --ignore-table="${dbname}".history_bin \
    --ignore-table="${dbname}".history_log \
    --ignore-table="${dbname}".history_str \
    --ignore-table="${dbname}".history_text \
    --ignore-table="${dbname}".history_uint \
    --ignore-table="${dbname}".trends \
    --ignore-table="${dbname}".trends_uint \
```

This should reduce the backup size and speed up MySQL dump.
> In tests, a **9h+** database dump was reduced to about **20s**.